### PR TITLE
Fix: remove default value for aws --profile flag

### DIFF
--- a/aws/aws_integration_test.go
+++ b/aws/aws_integration_test.go
@@ -25,7 +25,6 @@ func TestEncryptDecryptWithAWS(t *testing.T) {
 	profile := os.Getenv("AWS_PROFILE")
 	require.NotEmpty(t, key)
 	require.NotEmpty(t, region)
-	require.NotEmpty(t, profile)
 
 	crypt := crypto.New(New(key, region, profile))
 

--- a/main.go
+++ b/main.go
@@ -220,7 +220,7 @@ func encrypt() cli.Command {
 					},
 					cli.StringFlag{
 						Name:        "profile",
-						Value:       aws.DefaultProfile,
+						Value:       "",
 						Usage:       "the AWS API credentials profile",
 						Destination: &awsProfile,
 					},
@@ -458,7 +458,7 @@ func decrypt() cli.Command {
 					},
 					cli.StringFlag{
 						Name:        "profile",
-						Value:       aws.DefaultProfile,
+						Value:       "",
 						Usage:       "the AWS API credentials profile",
 						Destination: &awsProfile,
 					},


### PR DESCRIPTION
Removing the default value of the `--profile` flag used to create the AWS session. The value, if not passed, should be retrieved from the environment variable `AWS_PROFILE` (already done by the AWS SDK), or left empty if not present. 

Closes #25 